### PR TITLE
Sample code for PayPal PriorAuthorizationCapture API

### DIFF
--- a/src/main/java/net/authorize/sample/PayPalExpressCheckout/PriorAuthorizationCapture.java
+++ b/src/main/java/net/authorize/sample/PayPalExpressCheckout/PriorAuthorizationCapture.java
@@ -1,0 +1,69 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package net.authorize.sample.PayPalExpressCheckout;
+
+import java.math.BigDecimal;
+import net.authorize.api.controller.base.ApiOperationBase;
+import net.authorize.api.contract.v1.*;
+import net.authorize.api.controller.CreateTransactionController;
+import net.authorize.Environment;
+
+/**
+ *
+ * @author gnongsie
+ */
+public class PriorAuthorizationCapture {
+    public static void run(String apiLoginId, String apiTransactionKey, String transactionId){
+        System.out.println("Paypal Prior Authorization Transaction");
+        
+        //Common code to set for all requests
+        ApiOperationBase.setEnvironment(Environment.SANDBOX);
+        
+        // Define the merchant information (Authentication / Transaction ID)
+        MerchantAuthenticationType merchantAuthenticationType  = new MerchantAuthenticationType() ;
+            merchantAuthenticationType.setName(apiLoginId);
+            merchantAuthenticationType.setTransactionKey(apiTransactionKey);
+        ApiOperationBase.setMerchantAuthentication(merchantAuthenticationType);
+
+        // Populate the payment data
+        PayPalType payPalType = new PayPalType();
+            payPalType.setCancelUrl("http://www.merchanteCommerceSite.com/Success/TC25262");
+            payPalType.setSuccessUrl("http://www.merchanteCommerceSite.com/Success/TC25262");
+
+        // Standard api call to retrieve response
+        PaymentType paymentType = new PaymentType();
+            paymentType.setPayPal(payPalType);
+        
+        // Create the payment transaction request
+        TransactionRequestType transactionRequest = new TransactionRequestType();
+            transactionRequest.setTransactionType(TransactionTypeEnum.PRIOR_AUTH_CAPTURE_TRANSACTION.value());
+            transactionRequest.setPayment(paymentType);
+            transactionRequest.setAmount(BigDecimal.valueOf(19.99));
+            transactionRequest.setRefTransId(transactionId);
+
+        // Make the API Request
+        CreateTransactionRequest request = new CreateTransactionRequest();
+            request.setTransactionRequest(transactionRequest);
+        
+        // Instantiate the contoller that will call the service
+        CreateTransactionController controller = new CreateTransactionController(request);
+            controller.execute();
+            
+        CreateTransactionResponse response = controller.getApiResponse();
+        
+        // If API Response is ok, go ahead and check the transaction response
+        if (response.getMessages().getResultCode() == MessageTypeEnum.OK){
+            if (response.getTransactionResponse() != null){
+                System.out.println("Success, Auth Code: " + response.getTransactionResponse().getAuthCode());
+            }
+        }
+        else{
+            System.out.println("Error: " + response.getMessages().getMessage().get(0).getCode() + 
+                                    " " + response.getMessages().getMessage().get(0).getText());
+        }
+    }
+}

--- a/src/main/java/net/authorize/sample/SampleCode.java
+++ b/src/main/java/net/authorize/sample/SampleCode.java
@@ -3,12 +3,14 @@ package net.authorize.sample;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.*;
 
 import net.authorize.sample.VisaCheckout.*;
 import net.authorize.sample.PaymentTransactions.*;
 import net.authorize.sample.RecurringBilling.*;
 import net.authorize.sample.TransactionReporting.*;
 import net.authorize.sample.CustomerProfiles.*;
+import net.authorize.sample.PayPalExpressCheckout.*;
 
 /**
  * Created by anetdeveloper on 8/5/15.
@@ -106,6 +108,7 @@ public class SampleCode {
         System.out.println("    GetHostedProfilePage");
         System.out.println("    UpdateCustomerPaymentProfile");
         System.out.println("    UpdateCustomerShippingAddress");
+        System.out.println("    PaypalPriorAuthorizationCapture");
     }
 
     private static void RunMethod(String methodName)
@@ -221,6 +224,13 @@ public class SampleCode {
                 break;
             case "UpdateCustomerShippingAddress":
                 UpdateCustomerShippingAddress.run(apiLoginId, transactionKey);
+                break;
+            case "PaypalPriorAuthorizationCapture":
+                Scanner reader = new Scanner(System.in);
+                System.out.println("Enter Transaction ID: ");
+                String transactionId = reader.nextLine();
+                
+                PriorAuthorizationCapture.run(apiLoginId, transactionKey, transactionId);
                 break;
             default:
                 ShowUsage();


### PR DESCRIPTION
Adding sample code for API to PriorAuthorizationCapture of PayPal transaction. 

Transaction ID is taken as input from Console.

Reviewed by : Saptarshi Basu (Github ID: sapta89)
