### PR TITLE
fix the namespace for the main file "SampleCode.java"

### DIFF
--- a/src/main/java/net/authorize/sample/SampleCode.java
+++ b/src/main/java/net/authorize/sample/SampleCode.java
@@ -12,6 +12,7 @@ import net.authorize.sample.RecurringBilling.*;
 import net.authorize.sample.TransactionReporting.*;
 import net.authorize.sample.CustomerProfiles.*;
 import net.authorize.sample.MobileInappTransactions.*;
+import net.authorize.sample.FraudManagement.*;
 /**
  * Created by anetdeveloper on 8/5/15.
  */


### PR DESCRIPTION
Due to miss in namespace i had build failure for the fraud APIs for sample-code-java. Can someone merge this change?