### PR TITLE
update Travis testing environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ sudo:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - oraclejdk9
   - openjdk7
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ sudo:
     false
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk7
+    - oraclejdk8
+    - oraclejdk9
+    - openjdk7
+
+matrix:
+    allow_failures:
+        - jdk: oraclejdk9
  


### PR DESCRIPTION
remove oraclejdk7 from testing and add oraclejdk9 (but allow travis failures on jdk9 until backward compatibility is worked out)