### PR TITLE
Adding unit tests for net.authorize.sample.Sha512.ComputeTransHashS512

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
 			<artifactId>junit</artifactId>
 			<version>4.8.1</version>
 		</dependency>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/test/java/net/authorize/sample/Sha512/ComputeTransHashSHA2Test.java
+++ b/src/test/java/net/authorize/sample/Sha512/ComputeTransHashSHA2Test.java
@@ -1,0 +1,59 @@
+package net.authorize.sample.Sha512;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ComputeTransHashSHA2Test {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getHMACSHA512InputNotNullNotNullOutputIllegalArgumentException() throws Exception {
+  	thrown.expect(IllegalArgumentException.class);
+    ComputeTransHashSHA2.getHMACSHA512("/", "/");
+  }
+
+  @Test
+  public void getHMACSHA512InputNotNullNotNullOutputIllegalArgumentException2() throws Exception {
+  	thrown.expect(IllegalArgumentException.class);
+    ComputeTransHashSHA2.getHMACSHA512(
+        "\u0003\u0001\u0001 \u0010\u0000      0                                                                       ",
+        "\u0000\u0000\u0000?????????????????????????????????????");
+  }
+
+  @Test
+  public void getHMACSHA512InputNotNullNullOutputIllegalArgumentException() throws Exception {
+  	thrown.expect(IllegalArgumentException.class);
+    ComputeTransHashSHA2.getHMACSHA512(
+        "\u8003\u0001\u0000\u0000>\u0000\ubffe\ubffe\ubffe\u0003",
+        null);
+  }
+
+  @Test
+  public void getHMACSHA512InputNullNotNullOutputIllegalArgumentException() throws Exception {
+  	thrown.expect(IllegalArgumentException.class);
+    ComputeTransHashSHA2.getHMACSHA512(
+        null, "\u0000\u0000\u0000??????????????????????");
+  }
+
+  @Test
+  public void hexStringToByteArrayInputNotNullOutput0() {
+
+	  Assert.assertArrayEquals(new byte[] {}, ComputeTransHashSHA2.hexStringToByteArray(""));
+  }
+
+  @Test
+  public void hexStringToByteArrayInputNotNullOutputStringIndexOutOfBoundsException() {
+
+	  thrown.expect(StringIndexOutOfBoundsException.class);
+    ComputeTransHashSHA2.hexStringToByteArray("/");
+  }
+
+  @Test
+  public void hexStringToByteArrayInputNotNullOutputStringIndexOutOfBoundsException2() {
+	  thrown.expect(StringIndexOutOfBoundsException.class);
+    ComputeTransHashSHA2.hexStringToByteArray("#\uff77\u0002");
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `net.authorize.sample.Sha512.ComputeTransHashSHA512` is not fully tested.
I've written some tests for this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for other classes, I would be more than happy to look further.